### PR TITLE
Fix issues with analyzing Apache Linkis

### DIFF
--- a/src/build_system/maven_build.py
+++ b/src/build_system/maven_build.py
@@ -308,10 +308,23 @@ class MavenBuildSystem(BuildSystem):
                 cwd=self.project_path,
                 capture_output=True,
                 text=True,
-                timeout=60
+                timeout=120
             )
             
             success = result.returncode == 0
+            
+            # If 'resolve-sources' fails, try its older alias, 'sources'
+            if not success:
+                result = subprocess.run(
+                    ["mvn", "dependency:sources", "-q", "-DsilenceWarnings=true"],
+                    cwd=self.project_path,
+                    capture_output=True,
+                    text=True,
+                    timeout=120
+                )
+                
+                success = result.returncode == 0
+            
             if debug_logger.isEnabledFor(logging.DEBUG):
                 debug_logger.debug(f"Dependency resolution check: {success}")
                 if not success:

--- a/src/build_system/maven_build.py
+++ b/src/build_system/maven_build.py
@@ -559,7 +559,7 @@ class MavenBuildSystem(BuildSystem):
             has_test_src = src_test.exists() and any(src_test.rglob("*.java"))
             
             # Skip modules without source code (like BOM, distribution modules)
-            if not has_main_src and not has_test_src:
+            if not has_main_src or not has_test_src:
                 if debug_logger.isEnabledFor(logging.DEBUG):
                     debug_logger.debug(f"Skipping module without source code: {module_path.name}")
                 continue


### PR DESCRIPTION
This PR includes a few changes that allow the AIF analyzer to correctly detect the structure of [Apache Linkis](https://github.com/apache/linkis):

- Recursing over submodules in the check for Maven module paths
- Skipping over Maven modules without both main and test source sets
- Running the `dependency:sources` Maven task as a fallback for when `dependency:resolve-sources` fails