### PR TITLE
Fix incorrect Hamcrest dependency insertions in POM files

### DIFF
--- a/src/dependency_manager.py
+++ b/src/dependency_manager.py
@@ -265,9 +265,8 @@ class DependencyManager:
         for i, line in enumerate(lines):
             stripped = line.strip()
             
-            # Look for end of properties or start of build/plugins
-            if (stripped == '</properties>' or 
-                stripped in ['<build>', '<build >', '<profiles>', '<profiles >']):
+            # Look for end of properties
+            if stripped == '</properties>':
                 insertion_point = i + 1
                 # Extract base indentation
                 match = re.match(r'^(\s*)', line)

--- a/src/dependency_manager.py
+++ b/src/dependency_manager.py
@@ -209,6 +209,7 @@ class DependencyManager:
         lines = content.split('\n')
         
         # Find the dependencies section
+        in_plugin = False
         in_dependencies = False
         dependencies_start = -1
         dependencies_end = -1
@@ -217,8 +218,12 @@ class DependencyManager:
         for i, line in enumerate(lines):
             stripped = line.strip()
             
+            # Find start of plugin section
+            if stripped == '<plugin>' or stripped.startswith('<plugin '):
+                in_plugin = True
+            
             # Find start of dependencies section
-            if stripped == '<dependencies>' or stripped.startswith('<dependencies '):
+            if not in_plugin and (stripped == '<dependencies>' or stripped.startswith('<dependencies ')):
                 in_dependencies = True
                 dependencies_start = i
                 # Extract indentation from the dependencies tag
@@ -227,6 +232,10 @@ class DependencyManager:
                     base_indent = match.group(1)
                     indent = base_indent + "    "  # Add one level of indentation
                 continue
+            
+            # Find end of plugin section
+            if in_plugin and stripped == '</plugin>':
+                in_plugin = False
             
             # Find end of dependencies section
             if in_dependencies and stripped == '</dependencies>':


### PR DESCRIPTION
This PR fixes two issues with AIF's insertion of a Hamcrest dependency into POM files:

- `<dependencies>` blocks may be inserted within `<build>` or `<profiles>` blocks. This seems to be intentional, but these insertions cause the POM to become malformed.
- AIF will insert the Hamcrest dependency into `<dependencies>` blocks that are within `<plugin>` blocks, which causes the dependency to apply to the wrong part of the project (and, more importantly, causes a build error).